### PR TITLE
fix: Correctly report version numbers in dependencies API

### DIFF
--- a/app/api/dependencies/route.ts
+++ b/app/api/dependencies/route.ts
@@ -14,7 +14,7 @@ export function GET() {
 
   const dependencies = filteredLockFile.reduce((acc, dep) => {
     const [, name, version] = dep.split("@")
-    const cleanVersion = version?.match(/[0-9.]+(-[0-9]+)?/)?.[0] // Extract only the version number
+    const cleanVersion = version?.match(/[^:(]+/)?.[0] // Extract only the version number
 
     // @ts-ignore
     acc[`@${name}`] = cleanVersion


### PR DESCRIPTION
The dependencies API stripped part of the version number when extracting it from the pnpm-lock.yaml file. Eg `2.0.0-b1.3` became `2.0.0`.

A more robust matching pattern has therefore been implemented.